### PR TITLE
Fix refund total ignoring order-level custom totals (e.g. payment discounts...)

### DIFF
--- a/Model/Refund/RefundCalculator.php
+++ b/Model/Refund/RefundCalculator.php
@@ -25,9 +25,16 @@ class RefundCalculator
             throw new \InvalidArgumentException('items must not be empty');
         }
 
-        $orderItems = [];
+        $orderItems     = [];
+        $orderItemsBase = 0.0;
+        $orderItemsTax  = 0.0;
         foreach (($order->getItems() ?? []) as $oi) {
             $orderItems[(int) $oi->getItemId()] = $oi;
+            if ($oi->getParentItemId() !== null) {
+                continue; // children carry price=0; parent holds the row total
+            }
+            $orderItemsBase += (float) $oi->getRowTotal() - (float) $oi->getDiscountAmount();
+            $orderItemsTax  += (float) $oi->getTaxAmount();
         }
 
         $lines = [];
@@ -93,6 +100,27 @@ class RefundCalculator
         $total = $this->round4($itemsSubtotal + $taxRefund + $shippingRefund);
 
         $grandTotal = $this->round4((float) $order->getGrandTotal());
+
+        // Detect order-level adjustments that are not captured in item-level
+        // fields — e.g. payment-method discounts, gift cards, or any custom
+        // total collector that modifies grand_total without distributing to
+        // item discount_amount.  The gap is the authoritative grand_total minus
+        // the sum that item fields account for.  Distribute it proportionally
+        // to the fraction of the order's item value being returned, so that a
+        // partial return gets a fair share and a full return always matches
+        // grand_total exactly.
+        $orderLevelGap = $this->round4(
+            $grandTotal
+            - $orderItemsBase
+            - $orderItemsTax
+            - (float) $order->getShippingAmount()
+            - (float) $order->getShippingTaxAmount(),
+        );
+        if (abs($orderLevelGap) > 0.005 && $orderItemsBase > 0.0) {
+            $ratio = $itemsSubtotal / $orderItemsBase;
+            $total = $this->round4($total + $orderLevelGap * $ratio);
+        }
+
         // Epsilon 0.01 (one cent) accommodates Magento's 2-decimal rounding of
         // grand_total vs our 4-decimal sum of parts. Tighter values risk false
         // positives on valid orders with inclusive-tax rounding.

--- a/view/frontend/templates/withdraw/form.phtml
+++ b/view/frontend/templates/withdraw/form.phtml
@@ -77,6 +77,28 @@ if ($itemSelectorChild instanceof \MageMe\EUWithdrawal\Block\Withdraw\ItemSelect
     }
 }
 
+// Compute the order-level gap so the JS sidebar mirrors RefundCalculator
+// exactly. Any difference between grand_total and the item-field sum is an
+// order-level adjustment (payment-method discount, gift card, custom total)
+// that must be distributed proportionally in the refund preview.
+$orderItemsBase = 0.0;
+$orderItemsTax  = 0.0;
+foreach (($orderForMeta?->getItems() ?? []) as $oi) {
+    if ($oi->getParentItemId()) {
+        continue;
+    }
+    $orderItemsBase += (float) $oi->getRowTotal() - (float) $oi->getDiscountAmount();
+    $orderItemsTax  += (float) $oi->getTaxAmount();
+}
+$orderLevelGap = round(
+    (float) ($orderForMeta?->getGrandTotal() ?? 0.0)
+    - $orderItemsBase
+    - $orderItemsTax
+    - (float) ($orderForMeta?->getShippingAmount() ?? 0.0)
+    - (float) ($orderForMeta?->getShippingTaxAmount() ?? 0.0),
+    4, PHP_ROUND_HALF_EVEN,
+);
+
 // Inline Tabler-style stroke icons (CSP-safe, scale with currentColor).
 $icon = static function (string $name, string $class = 'mm-eu-w-icon', int $size = 20): string {
     $paths = [
@@ -114,6 +136,8 @@ $icon = static function (string $name, string $class = 'mm-eu-w-icon', int $size
             'shippingPaid'     => round($shippingPaid, 2),
             'shippingTax'      => round($shippingTax, 2),
             'eligibleItems'    => $eligibleItems,
+            'orderItemsBase'   => round($orderItemsBase, 4),
+            'orderLevelGap'    => round($orderLevelGap, 4),
             'i18n'             => [
                 'orderPrefix'        => (string) __('Order #'),
                 'qtyPrefix'          => (string) __('Qty: '),

--- a/view/frontend/web/js/withdrawal-summary.js
+++ b/view/frontend/web/js/withdrawal-summary.js
@@ -66,6 +66,11 @@
         // eligibleItems[id] = { qty: maxRemaining, taxAmount, qtyOrdered }
         // (legacy `unitTax` schema kept as fallback for cached pages)
         const eligibleItems = boot.eligibleItems || {};
+        // Order-level gap: difference between grand_total and the sum of item
+        // fields. Non-zero when a custom total (payment-method discount, gift
+        // card, …) modified grand_total without touching item discount_amount.
+        const orderItemsBase = Number(boot.orderItemsBase || 0);
+        const orderLevelGap  = Number(boot.orderLevelGap  || 0);
 
         const render = () => {
             let itemsTotal = 0;
@@ -182,7 +187,13 @@
             // shipping_amount + shipping_tax_amount). Tax row stays as the
             // pure sum of per-item line tax.
             const shippingRefundEx = fullReturn ? roundHalfEven(shippingPaid + shippingTax, 4) : 0;
-            const totalRefund = roundHalfEven(itemsTotal + tax + shippingRefundEx, 4);
+            // Distribute the order-level gap proportionally, mirroring
+            // RefundCalculator::calculate() on the server side.
+            let orderLevelAdj = 0;
+            if (Math.abs(orderLevelGap) > 0.005 && orderItemsBase > 0) {
+                orderLevelAdj = roundHalfEven(orderLevelGap * (itemsTotal / orderItemsBase), 4);
+            }
+            const totalRefund = roundHalfEven(itemsTotal + tax + shippingRefundEx + orderLevelAdj, 4);
 
             if (itemsTotalEl) itemsTotalEl.textContent = formatPrice(itemsTotal, currency);
             if (shippingPaidEl) shippingPaidEl.textContent = formatPrice(shippingRefundEx, currency);


### PR DESCRIPTION
RefundCalculator computed the refund by summing per-item row_total minus item-level discount_amount. This missed any order-level adjustment stored outside item fields — e.g. a payment-method discount (Fooman Surcharge) that is recorded as a custom total and reduces grand_total without distributing to item discount_amount.

For such orders the calculator produced a total higher than grand_total, causing the post-condition guard to throw a LogicException and rolling back the entire withdrawal submission. The JS sidebar preview also displayed the inflated amount.

Fix: after computing the item-based total, derive the order-level gap as
    `gap = grand_total - (sum(row_total - discount_amount) + sum(tax) + shipping + shipping_tax)`
and distribute it proportionally to the fraction of the order's item value being returned (`ratio = itemsSubtotal / orderItemsBase`). A full return produces ratio 1.0 and always yields grand_total; a partial return gets a fair proportional share. The gap is zero for standard orders, so there is no behavioural change for orders without custom totals.

The same computation is added to form.phtml (passed to JS as orderItemsBase + orderLevelGap) and withdrawal-summary.js so the live sidebar preview stays in sync with the server calculation.